### PR TITLE
Remove hardcoded javaOptions in build.sbt for universal:packageBin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -81,11 +81,6 @@ lazy val api = (project in file("."))
     mappings in Universal += file("conf/sample/vat_data.csv") -> "bin/conf/sample/vat_data.csv",
     mappings in Universal += file("conf/sample/paye_data.csv") -> "bin/conf/sample/paye_data.csv",
     mappings in Universal += file("conf/sample/company_house_data.csv") -> "bin/conf/sample/company_house_data.csv",
-    // Run with proper default env vars set for hbaseInMemory
-    javaOptions in Universal ++= Seq(
-      "-Dsource=hbaseInMemory",
-      "-Dsbr.hbase.inmemory=true"
-    ),
     libraryDependencies ++= Seq (
       filters,
       jdbc,


### PR DESCRIPTION
- Env vars can be passed in at runtime in CF